### PR TITLE
Fix error status check for Document SaveAs function

### DIFF
--- a/libreofficekit.go
+++ b/libreofficekit.go
@@ -173,7 +173,7 @@ func (document *Document) SaveAs(path string, format string, filter string) erro
 	cFilter := C.CString(filter)
 	defer C.free(unsafe.Pointer(cFilter))
 	status := C.document_save(document.handle, cPath, cFormat, cFilter)
-	if status != 0 {
+	if status != 1 {
 		return fmt.Errorf("Failed to save document")
 	}
 	return nil

--- a/libreofficekit_test.go
+++ b/libreofficekit_test.go
@@ -2,12 +2,15 @@ package libreofficekit
 
 import (
 	"testing"
+	"os"
 )
 
 const (
 	DefaultLibreOfficePath  = "/usr/lib/libreoffice/program/"
 	DocumentThatDoesntExist = "testdata/kittens.docx"
 	SampleDocument          = "testdata/sample.docx"
+	SaveDocumentPath        = "/tmp/out.docx"
+	SaveDocumentFormat      = "docx"
 )
 
 func TestInvalidOfficePath(t *testing.T) {
@@ -47,6 +50,21 @@ func TestSuccessLoadDocument(t *testing.T) {
 	if err != nil {
 		t.Fail()
 	}
+}
+
+func TestSuccessfulLoadAndSaveDocument(t *testing.T) {
+	office, _ := NewOffice(DefaultLibreOfficePath)
+	doc, err := office.LoadDocument(SampleDocument)
+	if err != nil {
+		t.Fail()
+	}
+
+	err = doc.SaveAs(SaveDocumentPath, SaveDocumentFormat, "")
+	if err != nil {
+		t.Fail()
+	}
+
+	defer os.Remove(SaveDocumentPath)
 }
 
 func TestGetPartPageRectangles(t *testing.T) {


### PR DESCRIPTION
LibreOfficeKit's `document_save` method currently returns a non-zero `status` code on success, but `go-libreofficekit` returns an `error` when `status != 0`. This changes the status check to `status != 1` and adds a unit test over the the expected behavior. 